### PR TITLE
Modify: サイドバーカテゴリのSSG対応

### DIFF
--- a/src/components/organisms/aside/AsideCategory.tsx
+++ b/src/components/organisms/aside/AsideCategory.tsx
@@ -1,77 +1,19 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
 import Link from 'next/link'
-import ReactLoading from 'react-loading'
-import useSWR from 'swr'
-import { client } from 'libs/client'
 import AsideTitle from 'src/components/atoms/aside/AsideTitle'
-import fetchZennData from 'src/pages/api/fetchZennData'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
 
-type CategoryCountAndPost = {
-  categoryName: string
-  categoryId: string
-  totalCount: string
+type Props = {
+  categoryData: CategoryCountAndPost[]
 }
 
-const AsideCategory = () => {
-  // 各カテゴリのページ情報の取得
-  const fetchCategories = async () => {
-    // 全てのカテゴリを取得
-    const categories = await client.getList({ endpoint: 'categories' })
-
-    // カテゴリと合計件数が入る配列
-    const categoryPosts: CategoryCountAndPost[] = []
-
-    // カテゴリ別の記事を取得
-    for (const category of categories.contents) {
-      const categoryPostData = await client.getList({
-        endpoint: 'posts',
-        queries: {
-          filters: `category[equals]${category.id}`,
-          limit: 999,
-        },
-      })
-
-      // カテゴリ別の記事のカテゴリIDと合計数の代入
-      categoryPosts.push({
-        categoryName: category.name,
-        categoryId: category.id,
-        totalCount: String(categoryPostData.totalCount),
-      })
-    }
-
-    // ToDo 仮でカテゴリ設置
-
-    // ToDo fetchのエラーの解決
-    // Zennデータの取得(api/fetchZennData.ts)
-    // const zennAllPostData = await fetchZennData()
-    // const zennPostData = await fetchZennData()
-    // console.log('zennPostData: ', zennPostData)
-    // console.log('zennAllPostData: ', zennAllPostData)
-
-    return categoryPosts
-  }
-
-  const { data, error } = useSWR('categories', fetchCategories)
-  if (error) console.log(error.message)
-
-  if (!data) {
-    return (
-      <div css={loading}>
-        <div css={loadingIcon}>
-          <ReactLoading type="spinningBubbles" color={'#1976D2'} />
-        </div>
-        <span css={loadingText}>カテゴリ取得中...</span>
-      </div>
-    )
-  }
-
-  // カテゴリの取得結果の判定
-  return data ? (
+const AsideCategory = ({ categoryData }: Props) => {
+  return (
     <>
       <ul css={categoryList}>
         <AsideTitle text={'Category'} />
-        {data.map((categoryData: CategoryCountAndPost) => (
+        {categoryData.map((categoryData: CategoryCountAndPost) => (
           <li key={categoryData.categoryId}>
             <Link href={`/category/${categoryData.categoryId}`}>
               {categoryData.categoryName}
@@ -81,9 +23,6 @@ const AsideCategory = () => {
         ))}
       </ul>
     </>
-  ) : (
-    // 取得失敗した場合は、カテゴリ自体を表示しない
-    <></>
   )
 }
 

--- a/src/components/templates/aside/AsideArchive.tsx
+++ b/src/components/templates/aside/AsideArchive.tsx
@@ -1,4 +1,3 @@
-import { NextPage } from 'next'
 import SearchForm from '../../molecules/aside/SearchForm'
 import AsideBase from './AsideBase'
 
@@ -6,14 +5,20 @@ import { Spacer } from 'src/components/molecules/Spacer'
 import AsideCategory from 'src/components/organisms/aside/AsideCategory'
 import AsidePopular from 'src/components/organisms/aside/AsidePopular'
 import AsideProfile from 'src/components/organisms/aside/AsideProfile'
-const AsideArchive: NextPage = () => {
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
+
+type Props = {
+  categoryData: CategoryCountAndPost[]
+}
+
+const AsideArchive = ({ categoryData }: Props) => {
   return (
     <AsideBase>
       <SearchForm />
       <Spacer size={30} />
       <AsideProfile />
       <Spacer size={30} />
-      <AsideCategory />
+      <AsideCategory categoryData={categoryData} />
       <Spacer size={30} />
       <AsidePopular />
     </AsideBase>

--- a/src/components/templates/aside/AsidePost.tsx
+++ b/src/components/templates/aside/AsidePost.tsx
@@ -11,8 +11,14 @@ import AsideBase from './AsideBase'
 import Share from 'src/components/molecules/Share'
 import { Spacer } from 'src/components/molecules/Spacer'
 import { mediaQuery } from 'src/utils/Breakpoints'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
 
-const AsidePost: NextPage<{ post: MicrocmsData }> = ({ post }) => {
+type Props = {
+  post: MicrocmsData
+  categoryData: CategoryCountAndPost[]
+}
+
+const AsidePost = ({ post, categoryData }: Props) => {
   return (
     <AsideBase>
       {post.toc_visible ? (
@@ -20,7 +26,7 @@ const AsidePost: NextPage<{ post: MicrocmsData }> = ({ post }) => {
           {/* 目次ありの場合 */}
           <AsideProfile />
           <Spacer size={30} />
-          <AsideCategory />
+          <AsideCategory categoryData={categoryData} />
           <Spacer size={30} />
           <AsidePopular />
           <Spacer size={30} />
@@ -37,7 +43,7 @@ const AsidePost: NextPage<{ post: MicrocmsData }> = ({ post }) => {
           {/* 目次なしの場合 */}
           <AsideProfile />
           <Spacer size={30} />
-          <AsideCategory />
+          <AsideCategory categoryData={categoryData} />
           <Spacer size={30} />
           <div css={sticky}>
             <SearchForm />

--- a/src/pages/api/fetchAsideCategory.ts
+++ b/src/pages/api/fetchAsideCategory.ts
@@ -1,0 +1,45 @@
+import fetchZennData from './fetchZennData'
+import { client } from 'libs/client'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
+
+async function fetchAsideCategory(): Promise<CategoryCountAndPost[]> {
+  // カテゴリと合計件数が入る配列
+  const categoryData: CategoryCountAndPost[] = []
+
+  // microCMSのブログのカテゴリを取得
+  const categories = await client.getList({ endpoint: 'categories' })
+
+  // カテゴリ別の記事を取得
+  for (const category of categories.contents) {
+    const categoryPostData = await client.getList({
+      endpoint: 'posts',
+      queries: {
+        filters: `category[equals]${category.id}`,
+        limit: 999,
+      },
+    })
+
+    // カテゴリ別の記事のカテゴリIDと合計数の代入
+    categoryData.push({
+      categoryName: category.name,
+      categoryId: category.id,
+      totalCount: String(categoryPostData.totalCount),
+    })
+  }
+
+  // Zennの記事を取得
+
+  // Zennデータの取得(api/fetchZennData.ts)
+  const zennAllPostData = await fetchZennData()
+
+  // Zenn記事のカテゴリIDと合計数の代入
+  categoryData.push({
+    categoryName: 'Zenn',
+    categoryId: 'zenn',
+    totalCount: String(zennAllPostData.length),
+  })
+
+  return categoryData
+}
+
+export default fetchAsideCategory

--- a/src/pages/api/fetchZennData.ts
+++ b/src/pages/api/fetchZennData.ts
@@ -28,7 +28,6 @@ const fetchZennData = async () => {
   const { items } = await parser.parseURL(
     `https://zenn.dev/${zennId}/feed?all=1`
   )
-
   // .catch((err) => console.log('以下のエラーが発生しました。\n', err))
 
   const zennPostData = items.map((item: ZennPostType) => {
@@ -39,23 +38,13 @@ const fetchZennData = async () => {
       content: item.content,
       createdAt,
       categoryName: 'Zenn',
-      categoryId: 'Zenn',
+      categoryId: 'zenn',
       isZenn: true,
       eyecatch: null, // ここで指定するとエラー出るためファイルで画像の指定する
       description: '', // 詳細ページないため不要
       updatedAt: '', // 詳細ページないため不要(一覧ページも投稿日のみでOK)
     }
   })
-
-  // let zennAllPostData = []
-
-  // for (const zennPost of zennPostData) {
-  //   zennAllPostData.push({
-  //     categoryName: zennPost.title,
-  //     categoryId: zennPost.id,
-  //     totalCount: String(zennPostData.length),
-  //   })
-  // }
 
   return zennPostData
 }

--- a/src/pages/category/[categoryId]/[pageNum].tsx
+++ b/src/pages/category/[categoryId]/[pageNum].tsx
@@ -15,6 +15,7 @@ import PostArchive from 'src/components/organisms/post/PostArchive'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBase from 'src/components/templates/BlogLayoutBase'
 import AsideArchive from 'src/components/templates/aside/AsideArchive'
+import fetchAsideCategory from 'src/pages/api/fetchAsideCategory'
 import { mediaQuery } from 'src/utils/Breakpoints'
 import { dateToString } from 'src/utils/dateToString'
 import { paginationRange } from 'src/utils/paginationRange'
@@ -26,6 +27,7 @@ const PER_PAGE = 6
 export default function CategoryId({
   blog,
   totalCount,
+  categoryData,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   if (blog.length === 0) {
     return <Failed text={'カテゴリに該当する記事はありません。'} />
@@ -46,7 +48,7 @@ export default function CategoryId({
           totalCount={totalCount}
         />
       </BlogLayoutBase>
-      <AsideArchive />
+      <AsideArchive categoryData={categoryData} />
     </BlogLayout>
   )
 }
@@ -83,10 +85,14 @@ export const getStaticProps: GetStaticProps = async (
     }
   })
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       blog: data,
       totalCount: data.length,
+      categoryData,
     },
   }
 }

--- a/src/pages/category/[categoryId]/index.tsx
+++ b/src/pages/category/[categoryId]/index.tsx
@@ -15,16 +15,18 @@ import PostArchive from 'src/components/organisms/post/PostArchive'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBase from 'src/components/templates/BlogLayoutBase'
 import AsideArchive from 'src/components/templates/aside/AsideArchive'
+import fetchAsideCategory from 'src/pages/api/fetchAsideCategory'
 import { mediaQuery } from 'src/utils/Breakpoints'
 import { dateToString } from 'src/utils/dateToString'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
 import { PostDataType } from 'types/PostDataType'
 import { microCmsPostData } from 'types/microCmsPostData'
-import { MicrocmsApi } from 'types/microcmsApi'
 import { MicrocmsData } from 'types/microcmsData'
 
 export default function CategoryId({
   blog,
   totalCount,
+  categoryData,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   if (blog.length === 0) {
     return <Failed text={'カテゴリに該当する記事はありません。'} />
@@ -45,7 +47,7 @@ export default function CategoryId({
           totalCount={totalCount}
         />
       </BlogLayoutBase>
-      <AsideArchive />
+      <AsideArchive categoryData={categoryData} />
     </BlogLayout>
   )
 }
@@ -80,10 +82,14 @@ export const getStaticProps: GetStaticProps = async (
     }
   })
 
+  // サイドバーのカテゴリ
+  const categoryData: CategoryCountAndPost[] = await fetchAsideCategory()
+
   return {
     props: {
       blog: data,
       totalCount: data.length,
+      categoryData,
     },
   }
 }

--- a/src/pages/category/zenn/[pageNum].tsx
+++ b/src/pages/category/zenn/[pageNum].tsx
@@ -9,6 +9,7 @@ import PostArchive from 'src/components/organisms/post/PostArchive'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBase from 'src/components/templates/BlogLayoutBase'
 import AsideArchive from 'src/components/templates/aside/AsideArchive'
+import fetchAsideCategory from 'src/pages/api/fetchAsideCategory'
 import fetchZennData from 'src/pages/api/fetchZennData'
 import { mediaQuery } from 'src/utils/Breakpoints'
 import { paginationRange } from 'src/utils/paginationRange'
@@ -19,6 +20,7 @@ const PER_PAGE = 6
 export default function CategoryId({
   blog,
   totalCount,
+  categoryData,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   if (blog.length === 0) {
     return <Failed text={'カテゴリに該当する記事はありません。'} />
@@ -36,7 +38,7 @@ export default function CategoryId({
 
         <CategoryPagination category="zenn" totalCount={totalCount} />
       </BlogLayoutBase>
-      <AsideArchive />
+      <AsideArchive categoryData={categoryData} />
     </BlogLayout>
   )
 }
@@ -45,10 +47,14 @@ export default function CategoryId({
 export const getStaticProps: GetStaticProps = async () => {
   const zennPostData = await fetchZennData()
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       blog: zennPostData,
       totalCount: zennPostData.length,
+      categoryData,
     },
   }
 }

--- a/src/pages/category/zenn/index.tsx
+++ b/src/pages/category/zenn/index.tsx
@@ -9,6 +9,7 @@ import PostArchive from 'src/components/organisms/post/PostArchive'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBase from 'src/components/templates/BlogLayoutBase'
 import AsideArchive from 'src/components/templates/aside/AsideArchive'
+import fetchAsideCategory from 'src/pages/api/fetchAsideCategory'
 import fetchZennData from 'src/pages/api/fetchZennData'
 import { mediaQuery } from 'src/utils/Breakpoints'
 import { PostDataType } from 'types/PostDataType'
@@ -18,6 +19,7 @@ const PER_PAGE = 6
 export default function CategoryId({
   blog,
   totalCount,
+  categoryData,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   if (blog.length === 0) {
     return <Failed text={'カテゴリに該当する記事はありません。'} />
@@ -37,7 +39,7 @@ export default function CategoryId({
 
         <CategoryPagination category="zenn" totalCount={totalCount} />
       </BlogLayoutBase>
-      <AsideArchive />
+      <AsideArchive categoryData={categoryData} />
     </BlogLayout>
   )
 }
@@ -47,10 +49,14 @@ export const getStaticProps: GetStaticProps = async () => {
   // Zennデータの取得(api/fetchZennData.ts)
   const zennPostData = await fetchZennData()
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       blog: zennPostData,
       totalCount: zennPostData.length,
+      categoryData,
     },
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import type { GetStaticProps, InferGetStaticPropsType } from 'next'
 import { memo } from 'react'
 import ArticleTitle from '../components/atoms/articleTitle/ArticleTitle'
 import Seo from '../components/molecules/Seo'
+import fetchAsideCategory from './api/fetchAsideCategory'
 import fetchMicrocmsData from './api/fetchMicrocmsData'
 import fetchZennData from './api/fetchZennData'
 import { BasicPagination } from 'src/components/organisms/pagination/BasicPagination'
@@ -33,15 +34,23 @@ export const getStaticProps: GetStaticProps = async () => {
   // [pageNum]に表示するデータ
   const displayData = data.slice(0, PER_PAGE)
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       data: displayData,
       totalCount: data.length,
+      categoryData,
     },
   }
 }
 const Home = memo(
-  ({ data, totalCount }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  ({
+    data,
+    totalCount,
+    categoryData,
+  }: InferGetStaticPropsType<typeof getStaticProps>) => {
     return (
       <>
         <Seo />
@@ -55,7 +64,7 @@ const Home = memo(
             </ul>
             <BasicPagination totalCount={totalCount} />
           </BlogLayoutBody>
-          <AsideArchive />
+          <AsideArchive categoryData={categoryData} />
         </BlogLayout>
       </>
     )

--- a/src/pages/posts/[post].tsx
+++ b/src/pages/posts/[post].tsx
@@ -1,12 +1,19 @@
 import { GetStaticPaths, NextPage } from 'next'
 import { client } from '../../../libs/client'
 import { MicrocmsData } from '../../../types/microcmsData'
+import fetchAsideCategory from '../api/fetchAsideCategory'
 import Comment from 'src/components/organisms/comment/Comment'
 
 import PostSingle from 'src/components/organisms/post/PostSingle'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBody from 'src/components/templates/BlogLayoutBase'
 import AsidePost from 'src/components/templates/aside/AsidePost'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
+
+type Props = {
+  post: MicrocmsData
+  categoryData: CategoryCountAndPost[]
+}
 
 // SSG
 export const getStaticProps = async (context: { params: MicrocmsData }) => {
@@ -18,9 +25,13 @@ export const getStaticProps = async (context: { params: MicrocmsData }) => {
 
   const data = await client.getListDetail({ endpoint: 'posts', contentId: id })
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       post: data,
+      categoryData,
     },
   }
 }
@@ -37,14 +48,14 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }
 }
 
-const Post: NextPage<{ post: MicrocmsData }> = ({ post }) => {
+const Post = ({ post, categoryData }: Props) => {
   return (
     <BlogLayout>
       <BlogLayoutBody>
         <PostSingle post={post} />
         <Comment id={post.id} />
       </BlogLayoutBody>
-      <AsidePost post={post} />
+      <AsidePost post={post} categoryData={categoryData} />
     </BlogLayout>
   )
 }

--- a/src/pages/posts/page/[pageNum].tsx
+++ b/src/pages/posts/page/[pageNum].tsx
@@ -13,6 +13,7 @@ import PostArchive from 'src/components/organisms/post/PostArchive'
 import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBody from 'src/components/templates/BlogLayoutBase'
 import AsideArchive from 'src/components/templates/aside/AsideArchive'
+import fetchAsideCategory from 'src/pages/api/fetchAsideCategory'
 import fetchMicrocmsData from 'src/pages/api/fetchMicrocmsData'
 import fetchZennData from 'src/pages/api/fetchZennData'
 import { mediaQuery } from 'src/utils/Breakpoints'
@@ -43,10 +44,14 @@ export const getStaticProps: GetStaticProps = async (
   // [pageNum]に表示するデータ
   const displayData = data.slice(offset, offset + PER_PAGE)
 
+  // サイドバーのカテゴリ
+  const categoryData = await fetchAsideCategory()
+
   return {
     props: {
       data: displayData,
       totalCount: data.length,
+      categoryData,
     },
   }
 }
@@ -71,6 +76,7 @@ export const getStaticPaths = async () => {
 const PostPage = ({
   data,
   totalCount,
+  categoryData,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const router = useRouter()
   return (
@@ -86,7 +92,7 @@ const PostPage = ({
           </ul>
           <BasicPagination totalCount={totalCount} />
         </BlogLayoutBody>
-        <AsideArchive />
+        <AsideArchive categoryData={categoryData} />
       </BlogLayout>
     </>
   )

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -16,12 +16,13 @@ import BlogLayout from 'src/components/templates/BlogLayout'
 import BlogLayoutBody from 'src/components/templates/BlogLayoutBase'
 import { mediaQuery } from 'src/utils/Breakpoints'
 import { dateToString } from 'src/utils/dateToString'
+import { CategoryCountAndPost } from 'types/CategoryCountAndPost'
 
 const fetcher = (url: string, value: string): Promise<any> => {
   return fetch(`${url}?keyword=${value}`).then((res) => res.json())
 }
 
-const Search = () => {
+const Search = ({ categoryData }: { categoryData: CategoryCountAndPost[] }) => {
   const router = useRouter()
 
   // apiでの検索結果を取得
@@ -37,7 +38,7 @@ const Search = () => {
         <BlogLayoutBody>
           <Failed text={'検索に失敗しました。'} />
         </BlogLayoutBody>
-        <AsideArchive />
+        <AsideArchive categoryData={categoryData} />
       </BlogLayout>
     )
   }
@@ -50,7 +51,7 @@ const Search = () => {
             <ReactLoading type="spinningBubbles" color={'#1976D2'} />
           </div>
         </BlogLayoutBody>
-        <AsideArchive />
+        <AsideArchive categoryData={categoryData} />
       </BlogLayout>
     )
   }
@@ -91,7 +92,7 @@ const Search = () => {
             </ul>
           )}
         </BlogLayoutBody>
-        <AsideArchive />
+        <AsideArchive categoryData={categoryData} />
       </BlogLayout>
     )
   }

--- a/types/CategoryCountAndPost.ts
+++ b/types/CategoryCountAndPost.ts
@@ -1,0 +1,5 @@
+export type CategoryCountAndPost = {
+  categoryName: string
+  categoryId: string
+  totalCount: string
+}


### PR DESCRIPTION
## issue: #16 

## 実装内容
- カテゴリの取得のみHTTP通信をしていたので、SSGに組み込んだ。
- ZennのデータとmicroCMSのデータを加工したものを、フェッチ関数として使いまわせるようにした。